### PR TITLE
Support FTPES(FTPS explicit mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Overview
 
+This plugin support **FTP**, **FTPES(FTPS explicit)**, **FTPS(FTPS implicit)** and doesn't support **SFTP**.
+
+If you want to use SFTP, please use [embulk-input-sftp](https://github.com/embulk/embulk-input-sftp).
+
+
 * **Plugin type**: file input
 * **Resume supported**: yes
 * **Cleanup supported**: yes
@@ -9,17 +14,32 @@
 ## Configuration
 
 - **host**: FTP server address (string, required)
-- **port**: FTP server port number (integer, default: `21`. `990` if `ssl` is true)
+- **port**: FTP server port number (integer, default: `21`. `990` if `ssl` is true and `ssl_explicit` is false)
 - **user**: user name to login (string, optional)
 - **password**: password to login (string, default: `""`)
 - **path_prefix** prefix of target files (string, required)
 - **passive_mode**: use passive mode (boolean, default: true)
 - **ascii_mode**: use ASCII mode instead of binary mode (boolean, default: false)
 - **ssl**: use FTPS (SSL encryption). (boolean, default: false)
+- **ssl_explicit** use FTPS(explicit) instead of FTPS(implicit). (boolean, default:true)
 - **ssl_verify**: verify the certification provided by the server. By default, connection fails if the server certification is not signed by one the CAs in JVM's default trusted CA list. (boolean, default: true)
 - **ssl_verify_hostname**: verify server's hostname matches with provided certificate. (boolean, default: true)
 - **ssl_trusted_ca_cert_file**: if the server certification is not signed by a certificate authority, set path to the X.508 certification file (pem file) of a private CA (string, optional)
 - **ssl_trusted_ca_cert_data**: similar to `ssl_trusted_ca_cert_file` but embed the contents of the PEM file as a string value instead of path to a local file (string, optional)
+
+### FTP / FTPS default port number
+
+FTP and FTPS server usually listens following port number(TCP) as default.
+
+Please be sure to configure firewall rules.
+
+|                         | FTP | FTPS(explicit) = FTPES | FTPS(implicit) = FTPS |
+|:------------------------|----:|-----------------------:|----------------------:|
+| Control channel port    |  21 |                     21 |             990 (\*1) |
+| Data channel port (\*2) |  20 |                     20 |                   989 |
+
+1. If you're using both of FTPS(implicit) and FTP, server may also listen 21/TCP for unecnrypted FTP.
+2. If you're using `passive mode`, data channel port can be taken between 1024 and 65535.
 
 ## Example
 

--- a/src/main/java/org/embulk/input/FtpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/FtpFileInputPlugin.java
@@ -51,9 +51,9 @@ public class FtpFileInputPlugin
         implements FileInputPlugin
 {
     private final Logger log = Exec.getLogger(FtpFileInputPlugin.class);
-    private static final Integer FTP_DEFULAT_PORT = 21;
-    private static final Integer FTPS_DEFAULT_PORT = 990;
-    private static final Integer FTPES_DEFAULT_PORT = 21;
+    private static final int FTP_DEFULAT_PORT = 21;
+    private static final int FTPS_DEFAULT_PORT = 990;
+    private static final int FTPES_DEFAULT_PORT = 21;
 
     public interface PluginTask
             extends Task, SSLPlugins.SSLPluginTask
@@ -164,7 +164,7 @@ public class FtpFileInputPlugin
     {
         FTPClient client = new FTPClient();
         try {
-            Integer defaultPort = FTP_DEFULAT_PORT;
+            int defaultPort = FTP_DEFULAT_PORT;
             if (task.getSsl()) {
                 client.setSSLSocketFactory(SSLPlugins.newSSLSocketFactory(task.getSSLConfig(), task.getHost()));
                 if (task.getSslExplicit()) {

--- a/src/main/java/org/embulk/input/FtpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/FtpFileInputPlugin.java
@@ -71,7 +71,6 @@ public class FtpFileInputPlugin
         @Config("port")
         @ConfigDefault("null")
         public Optional<Integer> getPort();
-        public void setPort(Optional<Integer> port);
 
         @Config("user")
         @ConfigDefault("null")
@@ -178,9 +177,7 @@ public class FtpFileInputPlugin
                     log.info("Using FTPS(FTPS/implicit) mode");
                 }
             }
-            if (!task.getPort().isPresent()) {
-                task.setPort(Optional.of(defaultPort));
-            }
+            int port = task.getPort().isPresent()? task.getPort().get() : defaultPort;
 
             client.addCommunicationListener(new LoggingCommunicationListner(log));
 
@@ -199,13 +196,8 @@ public class FtpFileInputPlugin
             //client.setDataTimeout
             //client.setAutodetectUTF8
 
-            if (task.getPort().isPresent()) {
-                client.connect(task.getHost(), task.getPort().get());
-                log.info("Connecting to {}:{}",task.getHost(),task.getPort().get());
-            } else {
-                client.connect(task.getHost());
-                log.info("Connecting to {}",task.getHost());
-            }
+            client.connect(task.getHost(), port);
+            log.info("Connecting to {}:{}",task.getHost(),port);
 
             if (task.getUser().isPresent()) {
                 log.info("Logging in with user "+task.getUser().get());


### PR DESCRIPTION
I changed code to support FTPES(FTPS explicit mode).
Current implementation works with FTPS(FTPS implicit mode), but doesn't works with FTPES(FTPS explicit mode).

I added `ssl_explicit(default: true)` option to support both of them.
I think it's better that plugin will use FTPES as a default mode. FTPES seems to be used widely than FTPS(implicit).
- FTPS(implicit) was written at [RFC4217 ver.7](https://tools.ietf.org/html/draft-murray-auth-ftp-ssl-07), but was removed at [ver.8](https://tools.ietf.org/html/draft-murray-auth-ftp-ssl-08).
- system administrator could force user to use FTPES instead of unencrypted FTP if server provides FTPES.
- vsftpd(probably a most common FTP daemon) uses FTPES as a default mode of FTPS.
## Backward compatibility

Although I changed default value of `port` option, I think this change keeps backward compatibility.
Because current version throw Exception if user executes without `port` option's setting.
