### PR TITLE
Support incremental option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - **user**: user name to login (string, optional)
 - **password**: password to login (string, default: `""`)
 - **path_prefix** prefix of target files (string, required)
+- **incremental** enables incremental loading(boolean, optional. default: true. If incremental loading is enabled, config diff for the next execution will include last_path parameter so that next execution skips files before the path. Otherwise, last_path will not be included.
 - **passive_mode**: use passive mode (boolean, default: true)
 - **ascii_mode**: use ASCII mode instead of binary mode (boolean, default: false)
 - **ssl**: use FTPS (SSL encryption). (boolean, default: false)

--- a/src/main/java/org/embulk/input/FtpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/FtpFileInputPlugin.java
@@ -62,6 +62,10 @@ public class FtpFileInputPlugin
         @ConfigDefault("null")
         public Optional<String> getLastPath();
 
+        @Config("incremental")
+        @ConfigDefault("true")
+        public boolean getIncremental();
+
         @Config("host")
         public String getHost();
 
@@ -130,15 +134,17 @@ public class FtpFileInputPlugin
         ConfigDiff configDiff = Exec.newConfigDiff();
 
         // last_path
-        if (task.getFiles().isEmpty()) {
-            // keep the last value
-            if (task.getLastPath().isPresent()) {
-                configDiff.set("last_path", task.getLastPath().get());
+        if (task.getIncremental()) {
+            if (task.getFiles().isEmpty()) {
+                // keep the last value
+                if (task.getLastPath().isPresent()) {
+                    configDiff.set("last_path", task.getLastPath().get());
+                }
+            } else {
+                List<String> files = new ArrayList<String>(task.getFiles());
+                Collections.sort(files);
+                configDiff.set("last_path", files.get(files.size() - 1));
             }
-        } else {
-            List<String> files = new ArrayList<String>(task.getFiles());
-            Collections.sort(files);
-            configDiff.set("last_path", files.get(files.size() - 1));
         }
 
         return configDiff;


### PR DESCRIPTION
In this PR, I added incremental option. This option was already implemented at [embulk-input-s3](https://github.com/embulk/embulk-input-s3) and works same.

We have a system that automates incremental data loading.
But some use cases don't need incremental data loading.

Instead, they load the entire data every time and replaces the data in the destination table every time. This flag controls the behavior.