### PR TITLE
Experimental: Build a JAR-based plugin file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ configurations {
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+group = "org.embulk.input.ftp"
 version = "0.1.5"
 
 dependencies {
@@ -24,6 +25,33 @@ dependencies {
     compile files("libs/ftp4j-1.7.2.jar")
     compile "org.bouncycastle:bcpkix-jdk15on:1.52"
     testCompile "junit:junit:4.+"
+}
+
+// EXPERIMENTAL: Builds a JAR-based plugin file with dependencies embedded.
+task pluginJar(type: Jar) {
+    destinationDir = file("pkg")
+
+    manifest {
+        attributes 'Embulk-Plugin-Spi-Version': "0",
+                   'Embulk-Plugin-Main-Class': "org.embulk.input.FtpFileInputPlugin",
+                   'Implementation-Title': project.name,
+                   'Implementation-Version': version
+    }
+
+    from {
+        // "provided" dependencies are excluded as they are provided at runtime by the Embulk core.
+        def embedded = configurations.runtime - configurations.provided
+
+        // Dependencies are picked up with extracting ".jar" files.
+        embedded.collect { ( it.isFile() && it.name.endsWith(".jar") ) ? zipTree(it) : it }
+    }
+
+    // Signature files of dependencies are excluded as they cause SecurityException.
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+    exclude("META-INF/*.SF")
+
+    with jar
 }
 
 task gemJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,14 @@ dependencies {
 task pluginJar(type: Jar) {
     destinationDir = file("pkg")
 
+    configurations {
+        pluginJarArtifact
+    }
+
+    artifacts {
+        pluginJarArtifact file: pluginJar.archivePath, builtBy: pluginJar
+    }
+
     manifest {
         attributes 'Embulk-Plugin-Spi-Version': "0",
                    'Embulk-Plugin-Main-Class': "org.embulk.input.FtpFileInputPlugin",
@@ -53,6 +61,7 @@ task pluginJar(type: Jar) {
 
     with jar
 }
+clean { delete "pkg" }
 
 task gemJar(type: Jar) {
     // JAR files, generated with the "gemJar" task, do not contain dependencies.


### PR DESCRIPTION
Trying to build a JAR-based plugin for Embulk's new pure-Java plugin mechanism.

1. Upgrading its Gradle to 3.5.1 (#9; not mandatory)
2. Renaming its "normal" JAR file to append "`-nodep`" (#10)
3. Adding a new Gradle task `pluginJar` to build a JAR-based plugin file (this)

Can you have a look, @muga?