### PR TITLE
Only build with Java8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,8 @@ subprojects {
         provided
     }
 
-    sourceCompatibility = 1.7
-    targetCompatibility = 1.7
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     dependencies {
         compile  "org.embulk:embulk-core:0.7.0"


### PR DESCRIPTION
Updated build.gradle to build only with Java8
I've not updated .travis.yml. Since it had already built only with Java8.
https://github.com/embulk/embulk-input-ftp/blob/v0.1.6/.travis.yml