### PR TITLE
Local testing with docker compose and use it by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
+sudo: required
 language: java
 jdk:
 - oraclejdk8
+services:
+  - docker
+before_script:
+- docker-compose up -d
+- docker-compose ps
 script:
 - ./gradlew --info check jacocoTestReport

--- a/README.md
+++ b/README.md
@@ -107,25 +107,32 @@ $ ./gradlew bintrayUpload # release embulk-input-sftp to Bintray maven repo
 
 ## Test
 
-```
+Firstly install Docker and Docker compose then `docker-compose up -d`,
+so that an FTP server will be locally launched then you can run tests with `./gradlew test`.
+
+```sh
+$ docker-compose up -d
+Creating network "embulk-input-ftp_default" with the default driver
+Creating embulk-input-ftp_server ... done
+
+$ docker-compose ps
+         Name              Command     State                       Ports                           
+---------------------------------------------------------------------------------------------------
+embulk-input-ftp_server   /start-ftp   Up      0.0.0.0:11021->21/tcp, 0.0.0.0:65000->65000/tcp, ...
+
 $ ./gradlew test  # -t to watch change of files and rebuild continuously
 ```
-To run unit tests, we need to configure the following environment variables.
 
-When environment variables are not set, skip some test cases.
+If you want to use other FTP server to test, configure the following environment variables.
 
 ```
-FTP_TEST_HOST
-FTP_TEST_USER
-FTP_TEST_PASSWORD
+FTP_TEST_HOST (default: localhost)
+FTP_TEST_PORT (default: 11021)
+FTP_TEST_SSL_PORT (default:990)
+FTP_TEST_USER (default: scott)
+FTP_TEST_PASSWORD (default: tigger)
 FTP_TEST_SSL_TRUSTED_CA_CERT_FILE
 FTP_TEST_SSL_TRUSTED_CA_CERT_DATA
-```
-
-Following option is optional
-```
-FTP_TEST_PORT (default:21)
-FTP_TEST_SSL_PORT (default:990)
 ```
 
 If you're using Mac OS X El Capitan and GUI Applications(IDE), like as follows.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  ftp_server:
+    container_name: embulk-input-ftp_server
+    image: "mcreations/ftp"
+    environment:
+      - FTP_USER=scott
+      - FTP_PASS=tiger
+      - HOST=localhost
+      - PASV_MIN_PORT=65000
+      - PASV_MAX_PORT=65004
+    ports:
+      - "11021:21"
+      - "65000-65004:65000-65004"
+    volumes:
+      - ./embulk-input-ftp/src/test/resources:/data/scott/unittest

--- a/embulk-input-ftp/src/test/java/org/embulk/input/TestFtpFileInputPlugin.java
+++ b/embulk-input-ftp/src/test/java/org/embulk/input/TestFtpFileInputPlugin.java
@@ -29,10 +29,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeNotNull;
 
 public class TestFtpFileInputPlugin
 {
@@ -58,17 +58,16 @@ public class TestFtpFileInputPlugin
     @BeforeClass
     public static void initializeConstant()
     {
-        FTP_TEST_HOST = System.getenv("FTP_TEST_HOST");
-        FTP_TEST_PORT = System.getenv("FTP_TEST_PORT") != null ? Integer.valueOf(System.getenv("FTP_TEST_PORT")) : 21;
-        FTP_TEST_SSL_PORT = System.getenv("FTP_TEST_SSL_PORT") != null ? Integer.valueOf(System.getenv("FTP_TEST_SSL_PORT")) : 990;
-        FTP_TEST_USER = System.getenv("FTP_TEST_USER");
-        FTP_TEST_PASSWORD = System.getenv("FTP_TEST_PASSWORD");
-        FTP_TEST_SSL_TRUSTED_CA_CERT_FILE = System.getenv("FTP_TEST_SSL_TRUSTED_CA_CERT_FILE");
-        FTP_TEST_SSL_TRUSTED_CA_CERT_DATA = System.getenv("FTP_TEST_SSL_TRUSTED_CA_CERT_DATA");
-        // skip test cases, if environment variables are not set.
-        assumeNotNull(FTP_TEST_HOST, FTP_TEST_USER, FTP_TEST_PASSWORD, FTP_TEST_SSL_TRUSTED_CA_CERT_FILE, FTP_TEST_SSL_TRUSTED_CA_CERT_DATA);
+        final Map<String, String> env = System.getenv();
+        FTP_TEST_HOST = env.getOrDefault("FTP_TEST_HOST", "localhost");
+        FTP_TEST_PORT = Integer.valueOf(env.getOrDefault("FTP_TEST_PORT", "11021"));
+        FTP_TEST_SSL_PORT = Integer.valueOf(env.getOrDefault("FTP_TEST_SSL_PORT", "990"));
+        FTP_TEST_USER = env.getOrDefault("FTP_TEST_USER", "scott");
+        FTP_TEST_PASSWORD = env.getOrDefault("FTP_TEST_PASSWORD", "tiger");
+        FTP_TEST_SSL_TRUSTED_CA_CERT_FILE = env.getOrDefault("FTP_TEST_SSL_TRUSTED_CA_CERT_FILE", "dummy");
+        FTP_TEST_SSL_TRUSTED_CA_CERT_DATA = env.getOrDefault("FTP_TEST_SSL_TRUSTED_CA_CERT_DATA", "dummy");
 
-        FTP_TEST_DIRECTORY = System.getenv("FTP_TEST_DIRECTORY") != null ? getDirectory(System.getenv("FTP_TEST_DIRECTORY")) : getDirectory("/unittest/");
+        FTP_TEST_DIRECTORY = getDirectory(env.getOrDefault("FTP_TEST_DIRECTORY", "/unittest/"));
         FTP_TEST_PATH_PREFIX = FTP_TEST_DIRECTORY + "sample_";
     }
 


### PR DESCRIPTION
It can make tests of `TestFtpFileInputPlugin` runnable in TravisCI.