### PR TITLE
Use file name output feature in Embulk core to show file name in cmdout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,13 +67,13 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
-        compile  "org.embulk:embulk-core:0.9.11"
-        provided "org.embulk:embulk-core:0.9.11"
+        compile  "org.embulk:embulk-core:0.9.12"
+        provided "org.embulk:embulk-core:0.9.12"
         compile files("${project.rootDir}/libs/ftp4j-1.7.2.jar")
         compile "org.bouncycastle:bcpkix-jdk15on:1.52"
         testCompile "junit:junit:4.+"
-        testCompile "org.embulk:embulk-core:0.9.11:tests"
-        testCompile "org.embulk:embulk-standards:0.9.11"
+        testCompile "org.embulk:embulk-core:0.9.12:tests"
+        testCompile "org.embulk:embulk-standards:0.9.12"
     }
 
     task classpath(type: Copy, dependsOn: ["jar"]) {
@@ -154,3 +154,4 @@ subprojects {
 task gemPush << {
     "gem push pkg/embulk-input-ftp-${project.version}.gem".execute().waitFor()
 }
+

--- a/embulk-input-ftp/src/main/java/org/embulk/input/FtpFileInputPlugin.java
+++ b/embulk-input-ftp/src/main/java/org/embulk/input/FtpFileInputPlugin.java
@@ -27,6 +27,7 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.TransactionalFileInput;
 import org.embulk.spi.util.InputStreamFileInput;
+import org.embulk.spi.util.InputStreamFileInput.InputStreamWithHints;
 import org.embulk.spi.util.ResumableInputStream;
 import org.embulk.spi.util.RetryExecutor.RetryGiveupException;
 import org.embulk.spi.util.RetryExecutor.Retryable;
@@ -597,16 +598,18 @@ public class FtpFileInputPlugin
         }
 
         @Override
-        public InputStream openNext() throws IOException
+        public InputStreamWithHints openNextWithHints() throws IOException
         {
             if (opened) {
                 return null;
             }
             opened = true;
 
-            return new ResumableInputStream(
-                    startDownload(log, client, path, 0L, executor),
-                    new FtpInputStreamReopener(log, client, executor, path));
+            return new InputStreamWithHints(
+                    new ResumableInputStream(
+                            startDownload(log, client, path, 0L, executor),
+                            new FtpInputStreamReopener(log, client, executor, path)), path
+            );
         }
 
         @Override


### PR DESCRIPTION
~Don't merge until new version Embulk is released that contains embulk/embulk#1066~
Same with embulk/embulk-input-s3#78