### PR TITLE
Move BlockingTransfer to embulk-input-ftp from embulk-util-ftp, with moving everything to org.embulk.input.ftp

### DIFF
--- a/embulk-input-ftp/build.gradle
+++ b/embulk-input-ftp/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.FtpFileInputPlugin"
+    mainClass = "org.embulk.input.ftp.FtpFileInputPlugin"
     category = "input"
     type = "ftp"
 }

--- a/embulk-input-ftp/src/main/java/org/embulk/input/ftp/BlockingTransfer.java
+++ b/embulk-input-ftp/src/main/java/org/embulk/input/ftp/BlockingTransfer.java
@@ -1,4 +1,4 @@
-package org.embulk.util.ftp;
+package org.embulk.input.ftp;
 
 import java.io.EOFException;
 import java.io.IOException;

--- a/embulk-input-ftp/src/main/java/org/embulk/input/ftp/FtpFileInputPlugin.java
+++ b/embulk-input-ftp/src/main/java/org/embulk/input/ftp/FtpFileInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.ftp;
 
 import it.sauronsoftware.ftp4j.FTPAbortedException;
 import it.sauronsoftware.ftp4j.FTPClient;
@@ -28,7 +28,6 @@ import org.embulk.util.config.TaskMapper;
 import org.embulk.util.file.InputStreamFileInput;
 import org.embulk.util.file.InputStreamFileInput.InputStreamWithHints;
 import org.embulk.util.file.ResumableInputStream;
-import org.embulk.util.ftp.BlockingTransfer;
 import org.embulk.util.ftp.SSLPlugins;
 import org.embulk.util.ftp.SSLPlugins.SSLPluginConfig;
 import org.embulk.util.retryhelper.RetryExecutor;

--- a/embulk-input-ftp/src/test/java/org/embulk/input/ftp/Pages.java
+++ b/embulk-input-ftp/src/test/java/org/embulk/input/ftp/Pages.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.ftp;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/embulk-input-ftp/src/test/java/org/embulk/input/ftp/TestBlockingTransfer.java
+++ b/embulk-input-ftp/src/test/java/org/embulk/input/ftp/TestBlockingTransfer.java
@@ -1,4 +1,4 @@
-package org.embulk.util.ftp;
+package org.embulk.input.ftp;
 
 public class TestBlockingTransfer
 {

--- a/embulk-input-ftp/src/test/java/org/embulk/input/ftp/TestFtpFileInputPlugin.java
+++ b/embulk-input-ftp/src/test/java/org/embulk/input/ftp/TestFtpFileInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.ftp;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -8,7 +8,7 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
 import org.embulk.config.TaskSource;
-import org.embulk.input.FtpFileInputPlugin.PluginTask;
+import org.embulk.input.ftp.FtpFileInputPlugin.PluginTask;
 import org.embulk.spi.FileInputPlugin;
 import org.embulk.spi.FileInputRunner;
 import org.embulk.spi.InputPlugin;


### PR DESCRIPTION
We spun off https://github.com/embulk/embulk-util-ssl instead of its `embulk-util-ftp`. But, `embulk-util-ssl` does not include `BlockingTransfer` because :
* It is not about SSL.
* It is used only from `embulk-input-ftp`, not shared with `embulk-output-ftp`.

Then, moving `BlockingTransfer` back in `embulk-input-ftp`.

At the same time, moving all classes to a package `org.embulk.input.ftp`.