### PR TITLE
Catch up with Embulk v0.10 API/SPI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,9 @@ plugins {
 
 repositories {
     mavenCentral()
+
+    // Tests need EmbulkTestRuntime. EmbulkTestRuntime needs old-style embulk-standards till 0.10.28. 0.10.28 needs jcenter.
+    // Tests call FileInputRunner directly. FileInputRunner needs old-style plugin architecture like 0.10.19. 0.10.19 needs jcenter.
     jcenter()
 }
 
@@ -18,13 +21,23 @@ description = "Reads files stored on a FTP server."
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation" << "-Xlint:unchecked"
+    options.encoding = "UTF-8"
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 dependencies {
     compileOnly "org.embulk:embulk-api:0.10.19"
     compileOnly "org.embulk:embulk-spi:0.10.19"
 
     compile("org.embulk:embulk-util-config:0.3.1") {
         // They conflict with embulk-core. They are once excluded here,
-        // and added explicitly with versions exactly the same with embulk-core:0.10.31.
+        // and added explicitly with versions exactly the same with embulk-core:0.10.19.
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
@@ -33,7 +46,7 @@ dependencies {
     }
 
     // They are once excluded from transitive dependencies of other dependencies,
-    // and added explicitly with versions exactly the same with embulk-core:0.10.31.
+    // and added explicitly with versions exactly the same with embulk-core:0.10.19.
     compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
     compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
@@ -44,10 +57,10 @@ dependencies {
     compile files("${project.rootDir}/libs/ftp4j-1.7.2.jar")
     compile "org.bouncycastle:bcpkix-jdk15on:1.52"
 
-    compile "org.embulk:embulk-util-file:0.1.1"
-    compile "org.embulk:embulk-util-retryhelper:0.8.0"
+    compile "org.embulk:embulk-util-file:0.1.3"
+    compile "org.embulk:embulk-util-retryhelper:0.8.2"
 
-    testCompile "junit:junit:4.13"
+    testCompile "junit:junit:4.13.2"
     testCompile "org.embulk:embulk-core:0.10.19"
     testCompile "org.embulk:embulk-core:0.10.19:tests"
     testCompile "org.embulk:embulk-standards:0.10.19"
@@ -60,14 +73,57 @@ embulkPlugin {
     type = "ftp"
 }
 
+javadoc {
+    options {
+        locale = "en_US"
+        encoding = "UTF-8"
+    }
+}
+
 publishing {
     publications {
-        maven(MavenPublication) {  // Publish it with "publishMavenPublicationToMavenCentralRepository".
+        maven(MavenPublication) {
+            groupId = project.group
+            artifactId = project.name
+
             from components.java  // Must be "components.java". The dependency modification works only for it.
+            // javadocJar and sourcesJar are added by java.withJavadocJar() and java.withSourcesJar() above.
+            // See: https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPluginExtension.html
+
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                packaging "jar"
+
+                name = project.name
+                description = project.description
+                url = "https://www.embulk.org/"
+
+                licenses {
+                    license {
+                        // http://central.sonatype.org/pages/requirements.html#license-information
+                        name = "The Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                    }
+                }
+
+                developers {
+                }
+
+                scm {
+                    connection = "scm:git:git://github.com/embulk/embulk-input-ftp.git"
+                    developerConnection = "scm:git:git@github.com:embulk/embulk-input-ftp.git"
+                    url = "https://github.com/embulk/embulk-input-ftp"
+                }
+            }
         }
     }
 
-    // TODO: Release it as a Maven artifact once the source of ftp4j is cleared.
+    repositories {
+        // It is not ready to release into Maven Central while FTP4J:1.7.2 is not available in Maven Central.
+    }
+}
+
+signing {
+    sign publishing.publications.maven
 }
 
 gem {

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -9,6 +9,6 @@ javax.validation:validation-api:1.1.0.Final
 org.bouncycastle:bcpkix-jdk15on:1.52
 org.bouncycastle:bcprov-jdk15on:1.52
 org.embulk:embulk-util-config:0.3.1
-org.embulk:embulk-util-file:0.1.1
-org.embulk:embulk-util-retryhelper:0.8.0
+org.embulk:embulk-util-file:0.1.3
+org.embulk:embulk-util-retryhelper:0.8.2
 org.embulk:embulk-util-ssl:0.3.0

--- a/src/main/java/org/embulk/input/ftp/FtpFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/ftp/FtpFileInputPlugin.java
@@ -143,7 +143,7 @@ public class FtpFileInputPlugin
         // TODO what if task.getFiles().isEmpty()?
 
         // number of processors is same with number of files
-        return resume(task.dump(), task.getFiles().size(), control);
+        return resume(task.toTaskSource(), task.getFiles().size(), control);
     }
 
     @Override

--- a/src/test/java/org/embulk/input/ftp/Pages.java
+++ b/src/test/java/org/embulk/input/ftp/Pages.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
+import org.embulk.spi.Exec;
 import org.embulk.spi.Page;
 import org.embulk.spi.PageReader;
 import org.embulk.spi.Schema;
@@ -26,7 +27,7 @@ class Pages
     {
         final ArrayList<Object[]> builder = new ArrayList<>();
         Iterator<Page> ite = pages.iterator();
-        try (PageReader reader = new PageReader(schema)) {
+        try (PageReader reader = Exec.getPageReader(schema)) {
             while (ite.hasNext()) {
                 reader.setPage(ite.next());
                 while (reader.nextRecord()) {

--- a/src/test/java/org/embulk/input/ftp/TestFtpFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/ftp/TestFtpFileInputPlugin.java
@@ -43,12 +43,7 @@ import static org.junit.Assert.assertEquals;
 
 public class TestFtpFileInputPlugin
 {
-    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder()
-            .addDefaultModules()
-            .addModule(new TypeModule())
-            .addModule(new ColumnModule())
-            .addModule(new SchemaModule())
-            .build();
+    private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY = ConfigMapperFactory.builder().addDefaultModules().build();
 
     private static String FTP_TEST_HOST;
     private static Integer FTP_TEST_PORT;
@@ -115,7 +110,7 @@ public class TestFtpFileInputPlugin
         final PluginTask task = configMapper.map(config(), PluginTask.class);
         task.setSSLConfig(sslConfig(task));
         task.setFiles(Arrays.asList("in/aa/a"));
-        final ConfigDiff configDiff = plugin.resume(task.dump(), 0, new FileInputPlugin.Control()
+        final ConfigDiff configDiff = plugin.resume(task.toTaskSource(), 0, new FileInputPlugin.Control()
         {
             @Override
             public List<TaskReport> run(final TaskSource taskSource, final int taskCount)
@@ -131,7 +126,7 @@ public class TestFtpFileInputPlugin
     {
         final ConfigMapper configMapper = CONFIG_MAPPER_FACTORY.createConfigMapper();
         final PluginTask task = configMapper.map(config(), PluginTask.class);
-        plugin.cleanup(task.dump(), 0, Lists.<TaskReport>newArrayList()); // no errors happens
+        plugin.cleanup(task.toTaskSource(), 0, Lists.<TaskReport>newArrayList()); // no errors happens
     }
 
     @Test


### PR DESCRIPTION
Updating some libraries to catch up finally with Embulk v0.10.

It is still `compileOnly ...:0.10.19` and `testCompile ...:0.10.19`, not `0.10.31` nor `0.10.28`, but it's known and intentional. The main plugin code should work even with Embulk v0.10.31 and later.